### PR TITLE
Rota1-022

### DIFF
--- a/decide/census/templates/census_by_group_remove.html
+++ b/decide/census/templates/census_by_group_remove.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{% block extrahead %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+
+    <link type="text/css" rel="stylesheet" href="{% static 'style.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+<div class="row justify-content-md-center align-items-center">
+    <div class="col-sm-8 justify-content-center align-items-center">
+        <h2>Census Groups Remove</h2>
+    </div>
+</div>
+<div class="row justify-content-md-center">
+    <div class="col-sm-8">
+        <h4>{% trans "Select which type of grouping you want to apply" %}</h4>
+    </div>
+</div>
+
+<div class="row">
+    
+</div>
+
+<div class="row justify-content-center submit">
+    <div class="col col-lg-2">
+        <a href="maritialStatus_remove"><button type="button" class="btn btn-primary group-button">{% trans "Maritial Status" %}</button></a>
+    </div>
+    <div class="col col-lg-2">
+        <a href="nationality"><button type="button" class="btn btn-primary group-button">{% trans "Nationality" %}</button></a>
+    </div>
+    <div class="col col-lg-2">
+        <a href="age"><button type="button" class="btn btn-primary group-button">{% trans "Age" %}</button></a>
+    </div>
+    <div class="col col-lg-2">
+        <a href="gender"><button type="button" class="btn btn-primary group-button">{% trans "Gender" %}</button></a>
+    </div>
+</div>
+
+{% if messages %}
+<ul class="messages" style="margin-top:2%">
+    {% for message in messages %}
+        {% if message.tags == 'error' %}
+        <li class="{{ message.tags }} alert alert-danger" role="alert">{{ message }}</li>
+        {% else %}
+        <li class="{{ message.tags }} alert alert-{{message.tags}}" role="alert">{{ message }}</li>
+        {% endif %}
+        
+    {% endfor %}
+</ul>
+
+{% endif %}
+{% include 'footer.html' %}
+
+{% endblock %}

--- a/decide/census/templates/census_by_group_remove.html
+++ b/decide/census/templates/census_by_group_remove.html
@@ -30,7 +30,7 @@
         <a href="maritialStatus_remove"><button type="button" class="btn btn-primary group-button">{% trans "Maritial Status" %}</button></a>
     </div>
     <div class="col col-lg-2">
-        <a href="nationality"><button type="button" class="btn btn-primary group-button">{% trans "Nationality" %}</button></a>
+        <a href="nationality_remove"><button type="button" class="btn btn-primary group-button">{% trans "Nationality" %}</button></a>
     </div>
     <div class="col col-lg-2">
         <a href="age"><button type="button" class="btn btn-primary group-button">{% trans "Age" %}</button></a>

--- a/decide/census/templates/census_maritialStatus_remove.html
+++ b/decide/census/templates/census_maritialStatus_remove.html
@@ -10,13 +10,15 @@
 
 
 {% block content %}
-<div class="title">
-    <h2>{% trans "Manage Census" %}</h2>
+<div class="row justify-content-md-center align-items-center">
+    <div class="col-sm-8 justify-content-center align-items-center">
+        <h2 class ="justify-content-center align-items-center">Census Groups Remove</h2>
+    </div>
 </div>
-
 <div class="row justify-content-md-center">
     <div class="col-sm-8">
-        <h4>{% trans "In this view you can manage the census by deleting a user from a specific voting" %}</h4>
+        <h3>Now you can remove groups of voters to an specific voting</h3>
+        <h6>for example, if you select Single, every user who satisfies that requirement will be removed from the chosen voting</h6>
     </div>
 </div>
 
@@ -24,7 +26,7 @@
     
 </div>
 
-<form class="row gx-3 gy-2 align-items-center" action="remove_from_census" method="POST">
+<form class="row gx-3 gy-2 align-items-center" action="maritialStatus/remove_by_maritialStatus_to_census" method="POST">
     {% csrf_token %}
     <div class="row justify-content-md-center">
         <div class="col-sm-8">
@@ -39,36 +41,34 @@
     </div>
     <div class="row justify-content-md-center">
         <div class="col-sm-8">
-            <label for="specificSizeSelect">{% trans "Choose a user" %}</label>
-            <select class="form-select" id="specificSizeSelect" name="user-select">
-                {% for user in users %}
-                <option value="{{user.id}}">{{user}}</option>
-                {%endfor%}
+            <label for="specificSizeSelect">{% trans "Maritial Status" %}</label>
+            <select multiple class="form-select" id="specificSizeSelect" name="maritialStatus-select">
+                <!--{% for maritialstatus in maritialStatus %}
+            <option value="{{maritialstatus}}">{{maritialstatus}}</option>
+                {%endfor%}-->
             </select>    
         </div>
     </div>
     <div class="row justify-content-center submit">
-        <div class="col col-lg-2">
+        <div class="col col-lg-1">
             <button type="submit" class="btn btn-primary">Submit</button>
         </div>
     </div>
 </form>
 
-<div class="row justify-content-center submit">
-    <div class="col col-lg-2">
-        <a href="by_group_remove"><button type="button" class="btn btn-primary group-button">Or Remove By Group</button></a>
-    </div>
-</div>
-
 {% if messages %}
-    <ul class="messages">
-        {% for message in messages %}
-            <li class="{{ message.tags }} alert alert-{{message.tags}}" role="alert">{{ message }}</li>
-        {% endfor %}
-    </ul>
+<ul class="messages" style="margin-top:2%">
+    {% for message in messages %}
+        {% if message.tags == 'error' %}
+        <li class="{{ message.tags }} alert alert-danger" role="alert">{{ message }}</li>
+        {% else %}
+        <li class="{{ message.tags }} alert alert-{{message.tags}}" role="alert">{{ message }}</li>
+        {% endif %}
+        
+    {% endfor %}
+</ul>
+
 {% endif %}
-
-
 
 {% include 'footer.html' %}
 {% endblock %}

--- a/decide/census/templates/census_nationality_remove.html
+++ b/decide/census/templates/census_nationality_remove.html
@@ -1,0 +1,74 @@
+{% extends "base.html" %}
+{% load i18n static %}
+
+{% block extrahead %}
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
+
+    <link type="text/css" rel="stylesheet" href="{% static 'style.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+<div class="row justify-content-md-center align-items-center">
+    <div class="col-sm-8 justify-content-center align-items-center">
+        <h2 class ="justify-content-center align-items-center">Census Groups Remove</h2>
+    </div>
+</div>
+<div class="row justify-content-md-center">
+    <div class="col-sm-8">
+        <h3>{% trans "Now you can add groups of voters to an specific voting" %}</h3>
+        <h6>for example, if you select Spain, every spanish user will be removed from the chosen voting</h6>
+    </div>
+</div>
+
+<div class="row">
+    
+</div>
+
+<form class="row gx-3 gy-2 align-items-center" action="nationality/add_by_nationality_to_census" method="POST">
+    {% csrf_token %}
+    <div class="row justify-content-md-center">
+        <div class="col-sm-8">
+            <label for="specificSizeSelect">{% trans "Choose a voting" %}</label>
+            <select class="form-select" id="specificSizeSelect" name="voting-select">
+                {% for voting in votings %}
+                <option value="{{voting.id}}">{{voting}}</option>
+                {%endfor%}
+            </select>
+        </div>
+    </div>
+    <div class="row justify-content-md-center">
+        <div class="col-sm-8">
+            <label for="specificSizeSelect">{% trans "Nationality" %}</label>
+            <select multiple class="form-select" id="specificSizeSelect" name="nationality-select">
+                <select multiple class="form-select" id="specificSizeSelect" name="maritialStatus-select">
+                    <!--{% for nation in nationality %}
+                <option value="{{nation}}">{{nation}}</option>
+                    {%endfor%}-->
+                </select>  
+        </div>
+    </div>
+    <div class="row justify-content-center submit">
+        <div class="col col-lg-1">
+            <button type="submit" class="btn btn-primary">Submit</button>
+        </div>
+    </div>
+</form>
+
+{% if messages %}
+<ul class="messages" style="margin-top:2%">
+    {% for message in messages %}
+        {% if message.tags == 'error' %}
+        <li class="{{ message.tags }} alert alert-danger" role="alert">{{ message }}</li>
+        {% else %}
+        <li class="{{ message.tags }} alert alert-{{message.tags}}" role="alert">{{ message }}</li>
+        {% endif %}
+        
+    {% endfor %}
+</ul>
+
+{% endif %}
+
+{% include 'footer.html' %}
+{% endblock %}

--- a/decide/census/urls.py
+++ b/decide/census/urls.py
@@ -26,4 +26,6 @@ urlpatterns = [
     path('export/exporting_census/', views.exporting_census),
     path('import/', views.import_census),
     path('import/importing_census/', views.importing_census),
+    path('remove/by_group_remove/', views.census_group_remove, name='census_by_group_remove'),
+    path('remove/by_group_remove/maritialStatus_remove', views.census_maritialStatus_remove),
 ]

--- a/decide/census/urls.py
+++ b/decide/census/urls.py
@@ -28,4 +28,5 @@ urlpatterns = [
     path('import/importing_census/', views.importing_census),
     path('remove/by_group_remove/', views.census_group_remove, name='census_by_group_remove'),
     path('remove/by_group_remove/maritialStatus_remove', views.census_maritialStatus_remove),
+    path('remove/by_group_remove/nationality_remove', views.census_nationality_remove),
 ]

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -484,3 +484,46 @@ def remove_by_maritialStatus_to_census(request):
         return HttpResponse(template.render({}, request), status=ST_401)
 
 
+def census_nationality_remove(request):
+    if request.user.is_staff:
+        template = loader.get_template("census_nationality_remove.html")
+        votings = Voting.objects.all()
+        try:
+            nationality = set(u.nationality for u in User.objects.all())
+        except BaseException:
+            nationality = set()
+        context = {
+            'votings': votings,
+            'nationality': nationality,
+        }
+        return HttpResponse(template.render(context, request))
+    else:
+        template = loader.get_template("result_page.html")
+        messages.error(request, "You must be a staff member to access this page")
+
+        return HttpResponse(template.render({'export': True}, request), status=ST_401)
+
+def remove_by_nationality_to_census(request):
+    template = loader.get_template("result_page.html")
+    if request.user.is_staff:
+        voting_id = request.POST['voting-select']
+        nation = request.POST['nationality-select']
+        #quizas en este paso haya que hacer otro for. Cuando el atributo este implementado por parte de
+        #los compañeros de Rota 2, mirar como hicimos sugerencias en PGPI
+        users = User.objects.filter(nationality in nation)
+        for user in users:
+            try:
+                census_by_voting = Census.objects.get(voting_id=voting_id,voter_id=user.id)
+                census_by_voting.delete()
+            except Census.DoesNotExist:
+                pass
+        
+        census_by_voting.save()
+        messages.success(request, "Users removed to the voting correctly")
+        return HttpResponse(template.render({}, request))
+
+    else:
+        messages.error(request, "You must be a staff member to access this page")
+        return HttpResponse(template.render({}, request), status=ST_401)
+
+

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -425,4 +425,62 @@ def add_by_age_to_census(request):
         messages.error(request, "You must be a staff member to access this page")
         return HttpResponse(template.render({}, request), status=ST_401)
 
+##Remove by group from census
+def census_group_remove(request):
+    if request.user.is_staff:
+        template = loader.get_template("census_by_group_remove.html")
+        users = User.objects.all()
+        votings = Voting.objects.all()
+        context = {
+            'votings': votings,
+            'users': users
+        }
+        return HttpResponse(template.render(context, request))
+    else:
+        template = loader.get_template("result_page.html")
+        messages.error(request, "You must be a staff member to access this page")
+        return HttpResponse(template.render({}, request), status=ST_401)
+
+def census_maritialStatus_remove(request):
+    if request.user.is_staff:
+        template = loader.get_template("census_maritialStatus_remove.html")
+        votings = Voting.objects.all()
+        try:
+            maritialStatus = set(u.maritialStatus for u in User.objects.all())
+        except BaseException:
+            maritialStatus = set()
+        context = {
+            'votings': votings,
+            'maritialStatus': maritialStatus,
+        }
+        return HttpResponse(template.render(context, request))
+    else:
+        template = loader.get_template("result_page.html")
+        messages.error(request, "You must be a staff member to access this page")
+        return HttpResponse(template.render({}, request), status=ST_401)
+
+
+def remove_by_maritialStatus_to_census(request):
+    template = loader.get_template("result_page.html")
+    if request.user.is_staff:
+        voting_id = request.POST['voting-select']
+        maritialStatus = request.POST['maritialStatus-select']
+        #quizas en este paso haya que hacer otro for. Cuando el atributo este implementado por parte de
+        #los compañeros de Rota 2, mirar como hicimos sugerencias en PGPI
+        users = User.objects.filter(maritial_status in maritialStatus)
+        for user in users:
+            try:
+                census_by_voting = Census.objects.get(voting_id=voting_id,voter_id=user.id)
+                census_by_voting.delete()
+            except Census.DoesNotExist:
+                pass
+        
+        census_by_voting.save()
+        messages.success(request, "Users removed to the voting correctly")
+        return HttpResponse(template.render({}, request))
+
+    else:
+        messages.error(request, "You must be a staff member to access this page")
+        return HttpResponse(template.render({}, request), status=ST_401)
+
 


### PR DESCRIPTION
ID: Rota1-022

Description: Added Groups (Maritial Status and Nationality) Remove functionality

Summary:
-An admin can remove groups of voters (grouped by Maritial Status or Nationality) from an specific voting.
(This functionality will be 100% working when decide-part-rota-main Rota1-003 issue is completed.)

Changes:
-Changed views, urls and templates
-Added census_by_group_remove.html, census_maritialStatus_remove.html, census_nationality_remove.html